### PR TITLE
feat: add DeepEval verdict evaluation

### DIFF
--- a/fact-checker-system/agents/wikipedia_agent.py
+++ b/fact-checker-system/agents/wikipedia_agent.py
@@ -301,8 +301,14 @@ class WikipediaAgent:
 if __name__ == "__main__":
     agent = WikipediaAgent()
     result = agent.process_fact_check("Mozart could beat Bethoveen in a fist fight")
-    
+
     print("------------")
     print(f"Verdict: {result.verdict}")
     print(f"Confidence: {result.confidence}")
     print(f"Explanation: {result.context}")
+
+    # DeepEval verdict evaluation example
+    # from evaluation.verdict_evaluator import evaluate_verdict
+    # ground_truth_verdict = "FALSE"  # Set your expected answer here
+    # eval_result = evaluate_verdict(result.verdict, ground_truth_verdict)
+    # print("DeepEval verdict evaluation:", eval_result)

--- a/fact-checker-system/evaluation/verdict_evaluator.py
+++ b/fact-checker-system/evaluation/verdict_evaluator.py
@@ -1,0 +1,26 @@
+from deepeval import evaluate
+
+# Example function to evaluate a verdict
+
+def evaluate_verdict(prediction: str, ground_truth: str):
+    """
+    Evaluate the LLM's verdict against the ground truth using DeepEval.
+    Args:
+        prediction (str): The verdict from your agent (e.g., 'TRUE', 'FALSE', etc.)
+        ground_truth (str): The expected verdict label
+    Returns:
+        DeepEval result object
+    """
+    result = evaluate(
+        prediction=prediction,
+        ground_truth=ground_truth,
+        task_type="fact-checking"
+    )
+    return result
+
+# Example usage
+if __name__ == "__main__":
+    pred = "TRUE"
+    gt = "TRUE"
+    eval_result = evaluate_verdict(pred, gt)
+    print(eval_result)

--- a/fact-checker-system/requirements.txt
+++ b/fact-checker-system/requirements.txt
@@ -1,3 +1,4 @@
+deepeval
 # ZenML and ML Pipeline
 zenml[server]
 pymongo>=4.0.0


### PR DESCRIPTION
feat: add DeepEval verdict evaluation
- Integrated DeepEval verdict evaluation in WikipediaAgent ( uncomment when testing )
- Added evaluation folder for reusable verdict evaluation logic (example can be inserted in testing scripts )